### PR TITLE
[Dev] prefix command currently not supported

### DIFF
--- a/src/main/kotlin/tw/waterballsa/alpha/wsabot/Main.kt
+++ b/src/main/kotlin/tw/waterballsa/alpha/wsabot/Main.kt
@@ -13,7 +13,6 @@ import tw.waterballsa.alpha.wsabot.knowledgeking.commands.KingofQuizCommand
 // 3. control bot
 fun main(args: Array<String>) {
     bot(getEnv("BOT_TOKEN")) {
-        prefix { "+" } // ?
         configure {
             intents = Intents(Intent.GuildMessageReactions, Intent.DirectMessagesReactions)
         }


### PR DESCRIPTION
## Why need this change? / Root cause: 
Before Discord added slash commands, all bots had prefixed commands. A user would type the bot's prefix followed by a word or phrase to invoke a command, such as ?help or !help. However, this prefixed commands system isn't native to Discord! Developers made use of an on_message event to check if the message began with a certain character, then invoke the command. Every time a message was sent, the bot would see the message and check for its "prefix"
- 拿掉 prefix command 避免使用者去觸發 command 導致的異常錯誤
## Changes made:
- 移除 prefix command
## Test Scope / Change impact:
-
