### PR TITLE
[feature] implement self introduction channel auto threading

### DIFF
--- a/src/main/kotlin/tw/waterballsa/alpha/wsabot/selfintroduction/app/AutoThread.kt
+++ b/src/main/kotlin/tw/waterballsa/alpha/wsabot/selfintroduction/app/AutoThread.kt
@@ -1,0 +1,28 @@
+package tw.waterballsa.alpha.wsabot.selfintroduction.app
+
+import dev.kord.common.entity.ArchiveDuration
+import dev.kord.core.event.message.MessageCreateEvent
+import me.jakejmattson.discordkt.dsl.listeners
+import mu.KotlinLogging
+
+fun autoThreadListener() = listeners {
+    val logger = KotlinLogging.logger {}
+
+    on<MessageCreateEvent> {
+        val channelIdValue = message.channelId.value
+        val betaSelfIntroductionChannelId = 1039196068455399474u
+        val prodSelfIntroductionChannelId = 937992281837961257u
+        if (!listOf(betaSelfIntroductionChannelId, prodSelfIntroductionChannelId).contains(channelIdValue)) {
+            return@on
+        }
+        val author = message.asMessage().author!!
+        val threadName = "【${author.username}】"
+        discord.kord.rest.channel.startThreadWithMessage(
+            message.channelId,
+            message.id,
+            name = threadName,
+            ArchiveDuration.Week
+        ) {}
+        logger.info { "Thread $threadName created" }
+    }
+}


### PR DESCRIPTION
## Why need this change? / Root cause: 
- 在『自我介紹』頻道中自動開啟討論串
## Changes made:
- 新增 `MessageCreateEvent` listener 並過濾非『自我介紹』頻道以外的訊息
## Test Scope / Change impact:
- 『自我介紹』頻道中只要有發言，就會自動在下方開啟一則討論串
