### PR TITLE
personal leave

### DIFF
--- a/src/main/kotlin/tw/waterballsa/alpha/wsabot/Main.kt
+++ b/src/main/kotlin/tw/waterballsa/alpha/wsabot/Main.kt
@@ -1,27 +1,50 @@
 package tw.waterballsa.alpha.wsabot
 
-import ch.qos.logback.core.util.OptionHelper.getEnv
+import dev.kord.common.entity.Permission
+import dev.kord.common.entity.Permissions
 import dev.kord.core.event.message.MessageCreateEvent
-import dev.kord.gateway.Intent
-import dev.kord.gateway.Intents
+import dev.kord.gateway.*
 import me.jakejmattson.discordkt.dsl.bot
 import me.jakejmattson.discordkt.dsl.listeners
-import tw.waterballsa.alpha.wsabot.knowledgeking.commands.KingofQuizCommand
+import java.util.*
 
 // 1. declare commands
 // 2. listen to events
 // 3. control bot
+@OptIn(PrivilegedIntent::class)
 fun main(args: Array<String>) {
-    bot(getEnv("BOT_TOKEN")) {
-        prefix { "/" } // ?
+    bot(getBotToken()) {
+        prefix { "+" } // ?
         configure {
-            intents = Intents(Intent.GuildMessageReactions, Intent.DirectMessagesReactions)
+            intents = Intents(
+                Intent.GuildMessageReactions,
+                Intent.DirectMessagesReactions,
+                Intent.GuildScheduledEvents,
+                Intent.GuildVoiceStates,
+                Intent.GuildMembers,
+                Intent.Guilds,
+            )
+            defaultPermissions = Permissions(
+                Permission.All,
+                Permission.ViewGuildInsights,
+                Permission.ViewChannel,
+                Permission.ManageChannels
+            )
         }
+
     }
+}
+
+fun getBotToken(): String {
+    val properties = Properties()
+    val file = Thread.currentThread().contextClassLoader.getResourceAsStream("secret.properties")
+    properties.load(file)
+    return properties.getProperty("token")
 }
 
 fun logListeners() = listeners {
     on<MessageCreateEvent> {
-        println(message.content)
+        if (!(message.author?.isBot!!))
+            println(message.content)
     }
 }

--- a/src/main/kotlin/tw/waterballsa/alpha/wsabot/gaas/commands/PersonalLeave.kt
+++ b/src/main/kotlin/tw/waterballsa/alpha/wsabot/gaas/commands/PersonalLeave.kt
@@ -1,0 +1,65 @@
+package tw.waterballsa.alpha.wsabot.gaas.commands
+
+import dev.kord.common.entity.ButtonStyle
+import dev.kord.common.entity.Snowflake
+import dev.kord.common.entity.TextInputStyle
+import dev.kord.core.behavior.interaction.modal
+import dev.kord.core.behavior.interaction.respondEphemeral
+import dev.kord.core.entity.channel.TextChannel
+import dev.kord.core.entity.interaction.ComponentInteraction
+import dev.kord.core.event.guild.GuildScheduledEventCreateEvent
+import dev.kord.core.event.interaction.GuildModalSubmitInteractionCreateEvent
+import me.jakejmattson.discordkt.dsl.MenuButtonRowBuilder
+import me.jakejmattson.discordkt.dsl.listeners
+import me.jakejmattson.discordkt.extensions.createMenu
+import tw.waterballsa.alpha.wsabot.gaas.entities.GaasLeave
+import tw.waterballsa.alpha.wsabot.gaas.repositories.GaasLeaveRepository
+
+//val gaasConversationChannelId = 975351568398442507 // WSA - 遊戲微服務交流頻道
+val gaasConversationChannelId = Snowflake(1039197324062240820) // beta - 遊戲微服務交流頻道
+val gaasRoleId = (1039198138403135538).toULong()
+//val guildId = Snowflake(937992003415838761) // WSA server
+val guildId = Snowflake(1038654765896310804) // beta server
+//        TODO 尚未決定持久化實作框架，未來會賦值實作子類
+val gaasLeaveRepository = object : GaasLeaveRepository {
+    override fun takeLeave(gaasLeave: GaasLeave) {}
+}
+
+fun createAskForLeaveMenu() = listeners {
+    on<GuildScheduledEventCreateEvent> {
+        val gaasChannel = getGuild().getChannel(gaasConversationChannelId) as TextChannel
+        takeIf { scheduledEvent.name.contains("遊戲微服務") }
+            ?.run { createLeaveMenu(gaasChannel) }
+    }
+    on<GuildModalSubmitInteractionCreateEvent> {
+        val reason = interaction.textInputs["ask-leave-reason"]?.value ?: ""
+        val user = interaction.user.discriminator
+        gaasLeaveRepository.takeLeave(GaasLeave(user, reason))
+        interaction.respondEphemeral { content = "我們已收到你的請假資訊，期待你下週能來和我們暢聊你的開發成果！" }
+    }
+}
+
+private suspend fun createLeaveMenu(gaasChannel: TextChannel) =
+    gaasChannel.createMenu {
+        page {
+            title = "請假"
+            description = "本次讀書會無法參加者，請點此請假並留下請假事由"
+        }
+        buttons { createLeaveButton() }
+    }
+
+private fun MenuButtonRowBuilder.createLeaveButton() =
+    actionButton("申請", null, ButtonStyle.Primary) {
+        val isGaasMember = user.asMember(guildId).roleIds.any { it.value == gaasRoleId }
+        if (isGaasMember)
+            createLeaveModal()
+    }
+
+
+private suspend fun ComponentInteraction.createLeaveModal() =
+    modal("GaaS 請假申請單", "ask-leave-form") {
+        actionRow {
+            textInput(TextInputStyle.Short, "ask-leave-reason", "請假事由")
+            build()
+        }
+    }

--- a/src/main/kotlin/tw/waterballsa/alpha/wsabot/gaas/entities/GaasLeave.kt
+++ b/src/main/kotlin/tw/waterballsa/alpha/wsabot/gaas/entities/GaasLeave.kt
@@ -1,0 +1,11 @@
+package tw.waterballsa.alpha.wsabot.gaas.entities
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class GaasLeave(
+    val id: String,
+    val reason: String,
+    val createTime: String = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm").format(LocalDateTime.now())
+) {
+}

--- a/src/main/kotlin/tw/waterballsa/alpha/wsabot/gaas/repositories/GaasLeaveRepository.kt
+++ b/src/main/kotlin/tw/waterballsa/alpha/wsabot/gaas/repositories/GaasLeaveRepository.kt
@@ -1,0 +1,7 @@
+package tw.waterballsa.alpha.wsabot.gaas.repositories
+
+import tw.waterballsa.alpha.wsabot.gaas.entities.GaasLeave
+
+interface GaasLeaveRepository {
+    fun takeLeave(gaasLeave: GaasLeave)
+}


### PR DESCRIPTION
## Why need this change? / Root cause: 
- All of GaaS members can take a leave when event created
## Changes made:
- Main: add bot permissions.
- GaasLeave: data model of gaas leave.
- GaasLeaveRepository: interface of accessing gaas leave data.
- PersonalLeave: implement gaas personal leave logic.
## Test Scope / Change impact:
- Create an event with event name '遊戲微服務' 
- Click the apply leaving button in channel '遊戲微服務成員交流區' 
- Type the leaving reason and submit
- Confirm the message content '我們已收到你的請假資訊，期待你下週能來和我們暢聊你的開發成果！' when succeeded.
![image](https://user-images.githubusercontent.com/32290488/215256295-e857cfee-ed5d-434e-96bb-86cf5ef46b65.png)
